### PR TITLE
Fix the wrong url to the ZIP archive

### DIFF
--- a/Formula/googleplaycli.rb
+++ b/Formula/googleplaycli.rb
@@ -1,7 +1,7 @@
 class Googleplaycli < Formula
   desc "Command line interface for Google play"
   homepage "https://github.com/Vacxe/google-play-cli"
-  url "https://github.com/Vacxe/google-play-cli/releases/download/0.1.1/google-play-cli-0.1.2.zip"
+  url "https://github.com/Vacxe/google-play-cli/releases/download/0.1.2/google-play-cli-0.1.2.zip"
   sha256 "265c5e8cd2c1681fc6d9ca566f5ecd8e7ee736b4dde512a75ddda7c493e0b94b"
 
   bottle :unneeded


### PR DESCRIPTION
Update dir name from `0.1.1` to `0.1.2`
Fix https://github.com/Vacxe/google-play-cli/issues/3